### PR TITLE
Demo server improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "globals": "^9.9.0",
     "history": "^3.0.0",
     "morgan": "^1.7.0",
+    "ora": "^0.3.0",
     "react": "^15.2.1",
     "react-document-title": "^2.0.2",
     "react-dom": "^15.2.1",

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ var webpack = require('webpack');
 var config = require('./webpack.config');
 var ora = require('ora');
 
-var PORT = process.env.PORT || 3000;
+var port = process.env.PORT || 3000;
 
 var app = express();
 var compiler = webpack(config);
@@ -35,7 +35,7 @@ app.get('/css/bootstrap.min.css', function (req, res) {
 
 app.use(stormpath.init(app, {
   // Disable logging until startup, so that we can catch errors
-  // and display them nicely
+  // and display them nicely.
   debug: 'none',
   web: {
     produces: ['application/json'],
@@ -89,21 +89,19 @@ app.get('*', function (req, res) {
   res.sendFile(path.join(__dirname, 'build/index.html'));
 });
 
-spinner.text = 'Starting Dev Sever on port ' + PORT,
+spinner.text = 'Starting Dev Sever on port ' + port,
 spinner.start();
 
-app.listen(PORT, function () {
+app.listen(port, function () {
   spinner.succeed();
   spinner.text = 'Initializing Stormpath';
   spinner.start();
   app.on('stormpath.ready', function () {
     spinner.succeed();
-    console.log('\nListening at http://localhost:' + PORT);
-    // Now bring back error logging
+    console.log('\nListening at http://localhost:' + port);
+    // Now bring back error logging.
     app.get('stormpathLogger').transports.console.level = 'error';
   });
 }).on('error', failAndExit);
-
-
 
 app.on('stormpath.error', failAndExit);

--- a/server.js
+++ b/server.js
@@ -92,6 +92,9 @@ app.get('*', function (req, res) {
 spinner.text = 'Starting Dev Sever on port ' + port,
 spinner.start();
 
+app.on('error', failAndExit);
+app.on('stormpath.error', failAndExit);
+
 app.listen(port, function () {
   spinner.succeed();
   spinner.text = 'Initializing Stormpath';
@@ -102,6 +105,4 @@ app.listen(port, function () {
     // Now bring back error logging.
     app.get('stormpathLogger').transports.console.level = 'error';
   });
-}).on('error', failAndExit);
-
-app.on('stormpath.error', failAndExit);
+});

--- a/server.js
+++ b/server.js
@@ -5,9 +5,22 @@ var path = require('path');
 var express = require('express');
 var webpack = require('webpack');
 var config = require('./webpack.config');
+var ora = require('ora');
+
+var PORT = process.env.PORT || 3000;
 
 var app = express();
 var compiler = webpack(config);
+
+var spinner = ora({
+  interval: 100
+});
+
+function failAndExit(err) {
+  spinner.fail();
+  console.error(err.stack);
+  process.exit(1);
+}
 
 app.use(morgan('combined'));
 
@@ -21,6 +34,9 @@ app.get('/css/bootstrap.min.css', function (req, res) {
 });
 
 app.use(stormpath.init(app, {
+  // Disable logging until startup, so that we can catch errors
+  // and display them nicely
+  debug: 'none',
   web: {
     produces: ['application/json'],
     login: {
@@ -73,15 +89,21 @@ app.get('*', function (req, res) {
   res.sendFile(path.join(__dirname, 'build/index.html'));
 });
 
-app.on('stormpath.ready', function () {
-  console.log('Stormpath Ready');
+spinner.text = 'Starting Dev Sever on port ' + PORT,
+spinner.start();
 
-  app.listen(3000, 'localhost', function (err) {
-    if (err) {
-      console.log(err);
-      return;
-    }
-
-    console.log('Listening at http://localhost:3000');
+app.listen(PORT, function () {
+  spinner.succeed();
+  spinner.text = 'Initializing Stormpath';
+  spinner.start();
+  app.on('stormpath.ready', function () {
+    spinner.succeed();
+    console.log('\nListening at http://localhost:' + PORT);
+    // Now bring back error logging
+    app.get('stormpathLogger').transports.console.level = 'error';
   });
-});
+}).on('error', failAndExit);
+
+
+
+app.on('stormpath.error', failAndExit);


### PR DESCRIPTION
- `app.listen` does not return errors to the callback, you have to catch them with `app.on(‘error’, cb)`
- Allow the port to be defined by the environment (needed if you try to deploy this to heroku)
- Don’t explicitly bind to localhost, that can cause problems in environments that don’t define what that means - let the OS decide what the loopback adapter is
- Bringing in some console progress magic (ora module) to let you know what’s going on while this is booting up (I added the same stuff to the stormpath-spa-dev-server)
